### PR TITLE
fix: allow max_tokens: -1 in chat completion requests

### DIFF
--- a/crypto_models/schema.py
+++ b/crypto_models/schema.py
@@ -82,7 +82,7 @@ class ChatCompletionRequestBase(BaseModel):
     messages: List[Message] = Field(..., description="List of messages in the conversation")
     tools: Optional[List[Dict[str, Any]]] = Field(None, description="Available tools for the model")
     tool_choice: Optional[Union[str, Dict[str, Any]]] = Field(None, description="Tool choice configuration")
-    max_tokens: Optional[int] = Field(8192, ge=1, description="Maximum number of tokens to generate")
+    max_tokens: Optional[int] = Field(None, description="Maximum number of tokens to generate")
     seed: Optional[int] = Field(None, description="Random seed for generation")
     
     @validator("messages")
@@ -104,6 +104,15 @@ class ChatCompletionRequestBase(BaseModel):
             invalid_roles = [msg.role for msg in v if msg.role not in valid_roles]
             raise ValueError(f"invalid role(s): {invalid_roles[0]}")
                 
+        return v
+
+    @validator("max_tokens")
+    def validate_max_tokens(cls, v: Optional[int]) -> Optional[int]:
+        """Validate max_tokens - convert -1 to None and ensure positive values."""
+        if v is None or v == -1:
+            return None
+        if v < 1:
+            raise ValueError("max_tokens must be greater than or equal to 1")
         return v
 
     def is_vision_request(self) -> bool:


### PR DESCRIPTION
- Remove ge=1 constraint from max_tokens field definition
- Add custom validator to handle max_tokens: -1 by converting to None
- This fixes 422 validation errors when clients send max_tokens: -1
- Common pattern in AI APIs where -1/null means "no token limit"

Fixes: #422 validation error for max_tokens: -1

Issue when using Open-WebUI for tests:
```
DEBUG: 422 Validation Error - Raw request body: {"stream": true, "model": "qwen3-30b-a3b-q8", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": -1}
DEBUG: 422 Validation Error - Request URL: http://127.0.0.1:8080/v1/chat/completions
DEBUG: 422 Validation Error - Request headers: {'host': '127.0.0.1:8080', 'content-type': 'application/json', 'authorization': 'Bearer ---', 'accept': '*/*', 'accept-encoding': 'gzip, deflate, br', 'user-agent': 'Python/3.12 aiohttp/3.11.11', 'content-length': '115'}
DEBUG: 422 Validation Error - Validation errors: [{'type': 'greater_than_equal', 'loc': ('body', 'max_tokens'), 'msg': 'Input should be greater than or equal to 1', 'input': -1, 'ctx': {'ge': 1}}]
```