### PR TITLE
feat: migrate from mlx-flux to mlx-openai-server for image generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@ HASH=bafkreiclwlxc56ppozipczuwkmgnlrxrerrvaubc5uhvfs3g2hp3lftrwm
 download:
 	python eternal_zoo/download.py $(HASH)
 
-# Package versions
-MLX_FLUX_TAG=1.0.6
-MLX_OPENAI_SERVER_TAG=1.2.12
+MLX_OPENAI_SERVER_TAG=1.2.13
 ETERNAL_ZOO_TAG=2.0.27
 
 # Default target

--- a/eternal_zoo/manager.py
+++ b/eternal_zoo/manager.py
@@ -112,8 +112,8 @@ class EternalZooManager:
                 running_ai_command = self._build_chat_command(config)
             elif task == "image-generation":
                 logger.info(f"Starting image generation model: {config}")
-                if not shutil.which("mlx-flux"):
-                    raise EternalZooServiceError("mlx-flux command not found in PATH")
+                if not shutil.which("mlx-openai-server"):
+                    raise EternalZooServiceError("mlx-openai-server command not found in PATH")
                 running_ai_command = self._build_image_generation_command(config)
             elif task == "image-edit":
                 logger.warning(f"Image edit is not implemented yet: {config}")
@@ -908,10 +908,11 @@ class EternalZooManager:
                 lora_scales.append(value["scale"])
 
         command = [
-            "mlx-flux",
-            "serve",
+            "mlx-openai-server",
+            "launch",
             "--model-path", str(model_path),
             "--config-name", architecture,
+            "--model-type", "image-generation",
         ]
         
         # Validate LoRA parameters

--- a/mac.sh
+++ b/mac.sh
@@ -495,14 +495,7 @@ else
     log_error "mlx-openai-server installation failed. This may happen on Intel Macs or due to compatibility issues. Continuing with installation..."
 fi
 
-# Step 8: Install mlx-flux dependencies
-if update_package "mlx-flux" "https://github.com/0x9334/mlx-flux.git" "https://raw.githubusercontent.com/0x9334/mlx-flux/main/setup.py" "version=\"[0-9.]*\"" "pip install git+https://github.com/0x9334/mlx-flux.git" "$MLX_FLUX_TAG"; then
-    log_message "mlx-flux installation completed successfully."
-else
-    log_error "mlx-flux installation failed. This may happen on Intel Macs or due to compatibility issues. Continuing with installation..."
-fi
-
-# Step 9: Install eternal-zoo toolkit
+# Step 8: Install eternal-zoo toolkit
 update_package "eternal-zoo" "https://github.com/eternalai-org/eternal-zoo.git" "https://raw.githubusercontent.com/eternalai-org/eternal-zoo/main/eternal_zoo/__init__.py" "__version__ = \"[0-9.]*\"" "pip install git+https://github.com/eternalai-org/eternal-zoo.git" "$ETERNAL_ZOO_TAG"
 
 log_message "Setup completed successfully."


### PR DESCRIPTION
# Migrate from mlx-flux to mlx-openai-server for image generation

## Summary
This PR replaces the `mlx-flux` dependency with `mlx-openai-server` for image generation functionality, providing a more standardized and maintained solution.

## Changes
- **Manager**: Update image generation command from `mlx-flux serve` to `mlx-openai-server launch`
- **Dependencies**: Remove `mlx-flux` installation and update `mlx-openai-server` to v1.2.13
- **Configuration**: Add `--model-type "image-generation"` parameter for proper model initialization
- **Installation**: Simplify `mac.sh` by removing mlx-flux installation step