### PR TITLE
fix: clear reasoning_content and tool_calls when copying </think> chunk

### DIFF
--- a/eternal_zoo/apis.py
+++ b/eternal_zoo/apis.py
@@ -434,6 +434,8 @@ class ServiceHandler:
                                         # copy a chunk with </think>
                                         copy_chunk_obj = chunk_obj.model_copy(deep=True)
                                         copy_chunk_obj.choices[0].delta.content = "</think>\n\n"
+                                        copy_chunk_obj.choices[0].delta.reasoning_content = None
+                                        copy_chunk_obj.choices[0].delta.tool_calls = None
                                         yield f"data: {copy_chunk_obj.model_dump_json()}\n\n"
 
                                 # Handle finish reason - output accumulated tool calls


### PR DESCRIPTION
## Fix Streaming Tools Response Cleanup

### Summary
Fixes streaming response corruption when transitioning from thinking mode to regular content/tool calls by properly clearing stale data fields.

### Changes
- **Fixed**: Explicitly clear `reasoning_content` and `tool_calls` fields when creating `</think>` closing chunks
- **Prevents**: Data corruption in streaming responses for tool-enabled models
- **Maintains**: Clean transitions between thinking mode and regular responses